### PR TITLE
add spanish character support in regex

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -11,7 +11,7 @@ import (
 )
 
 var HumanRegex = regexp.MustCompile(`[ -~]`)
-var WordRegex = regexp.MustCompile(`\w+`)
+var WordRegex = regexp.MustCompile(`[\wíáóúñé]+`)
 
 type Decrypt struct {
 	Ciphers  []string
@@ -112,7 +112,7 @@ func (d *Decrypt) opensslDecrypt(cipher string, hashPath string, guess string) (
 func AsciiPrintable(s string) int {
 	count := 0
 	for _, r := range s {
-		if unicode.IsPrint(r) && r < unicode.MaxASCII {
+		if unicode.IsPrint(r) && ( strings.ContainsRune("íáóúñé", r) || r < unicode.MaxASCII){
 			count++
 		}
 


### PR DESCRIPTION
In AscIIPrintable, just added a check that the current rune's one of the Spanish special characters.  Regex should now matche those in addition to a-zA-Z0-9 as well.

This should mean that decrypting an all-English string + some accents gives a rank of 5.00, but have not tested that yet.
